### PR TITLE
Reduce release binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,9 @@ eyre = "0.6.8"
 
 # [build-dependencies]
 # prost-build = { version = "0.12" }
+
+[profile.release]
+strip = true  # Automatically strip symbols from the binary.
+opt-level = "z"  # Optimize for size
+lto = true # Link time optimization
+codegen-units = 1 # Limit code generation units

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ repository = "https://github.com/mollyim/mollysocket"
 keywords = ["unifiedpush", "molly", "signal"]
 # build = "src/build_proto.rs"
 
+[profile.release]
+strip = true  # Automatically strip symbols from the binary.
+opt-level = "s"  # Optimize for size
+lto = true # Link time optimization
+codegen-units = 1 # Limit code generation units
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -38,9 +44,3 @@ eyre = "0.6.8"
 
 # [build-dependencies]
 # prost-build = { version = "0.12" }
-
-[profile.release]
-strip = true  # Automatically strip symbols from the binary.
-opt-level = "z"  # Optimize for size
-lto = true # Link time optimization
-codegen-units = 1 # Limit code generation units


### PR DESCRIPTION
There are many safe flags we can apply to the release profile to reduce the file size.

https://github.com/johnthagen/min-sized-rust

Release binary went from 15MB -> 4.5MB on amd64.