### PR TITLE
Add webserver flag, allowing to disable web server entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The configuration file uses the [TOML format](https://toml.io/). Below is an ove
 |                        | MOLLY_CONF                 | -c \*       | Path to the configuration file, optional          |                      | /etc/mollysocket.conf                                   |
 | host                   | MOLLY_HOST              \* |             | Listening address of the web server               | 127.0.0.1            | 0.0.0.0                                                 |
 | port                   | MOLLY_PORT              \* |             | Listening port of the web server                  | 8020                 | 8080                                                    |
+| webserver              | MOLLY_WEBSERVER         \* |             | Wether to start the web server                    | true                 | false                                                   |
 | allowed_endpoints      | MOLLY_ALLOWED_ENDPOINTS \* |             | List of UnifiedPush servers                       | `["*"]`              | `["*"]`,`["https://yourdomain.tld","https://ntfy.sh"]`  |
 | allowed_uuids          | MOLLY_ALLOWED_UUIDS     \* |             | UUIDs of signal accounts that may use this server | `["*"]`              | `["*"]`, `["abcdef-12345-tuxyz-67890"]`                 |
 | db                     | MOLLY_DB                \* |             | Path to the DB                                    | `db.sqlite`          | `"/data/ms.sqlite"`                                     |

--- a/config-sample.toml
+++ b/config-sample.toml
@@ -1,4 +1,5 @@
 db = '/opt/mollysocket/mollysocket.db'
 allowed_endpoints = ['*']
 allowed_uuids = ['*']
+webserver = true
 port = 8020

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub enum SignalEnvironment {
 struct Config {
     host: String,
     port: u16,
+    webserver: bool,
     signal_env: SignalEnvironment,
     allowed_endpoints: Vec<String>,
     allowed_uuids: Vec<String>,
@@ -38,6 +39,7 @@ impl Default for Config {
         Self {
             host: String::from("127.0.0.1"),
             port: 8020,
+            webserver: true,
             signal_env: SignalEnvironment::Production,
             allowed_endpoints: vec![String::from("*")],
             allowed_uuids: vec![String::from("*")],
@@ -64,6 +66,10 @@ pub fn get_port() -> u16 {
 
 pub fn is_uuid_valid(uuid: &str) -> bool {
     get_cfg().is_uuid_valid(uuid)
+}
+
+pub fn should_start_webserver() -> bool {
+    get_cfg().webserver
 }
 
 pub fn get_ws_endpoint(uuid: &str, devide_id: u32, password: &str) -> String {

--- a/src/server/web.rs
+++ b/src/server/web.rs
@@ -164,6 +164,11 @@ fn gen_rep(mut map: HashMap<String, String>) -> Json<Response> {
 }
 
 pub async fn launch() {
+    if !config::should_start_webserver() {
+        log::warn!("The web server is disabled, making mollysocket run in an air gapped mode. With this clients are less easy to set up and push might break.");
+        return;
+    }
+
     let rocket_cfg = rocket::Config::figment()
         .merge(("address", &config::get_host()))
         .merge(("port", &config::get_port()));


### PR DESCRIPTION
Previously the web server would always start and there was no way to tell mollysocket to intentionally run air gapped. This pull request adds a new config option to allow preventing the web server from starting.