### PR TITLE
feat: reduce docker container size & improve health check

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,14 +5,17 @@ COPY . .
 RUN cargo build --release --bin mollysocket
 
 
-FROM docker.io/debian:bookworm as runtime
+FROM docker.io/debian:bookworm-slim as runtime
 WORKDIR app
 
-RUN apt update && \
-    apt install -y libssl3 libsqlite3-0 ca-certificates
+ENV MOLLY_HOST=127.0.0.1
+ENV MOLLY_PORT=8020
 
+RUN apt update && \
+    apt install -y wget libssl3 libsqlite3-0 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/mollysocket /usr/local/bin/
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD /usr/local/bin/mollysocket connection list
+HEALTHCHECK --interval=1m --timeout=3s \
+    CMD wget -q --tries=1 "http://$MOLLY_HOST:$MOLLY_PORT/" -O - | grep '"mollysocket":{"version":'
 ENTRYPOINT ["/usr/local/bin/mollysocket"]


### PR DESCRIPTION
This PR reduces the docker image size by 40%, from ~150MB to ~90MB. It does this by using the `bookworm-slim` container instead of `bookworm` and it removes the apt list caches. The last change means that if you are debugging and you need to install additional packages you need to run apt update within the container first.
I didn't try really hard but I couldn't get mollysocket to build on Alpine Linux, that would've reduced the image size probably even further as the base layer of Alpine Linux is just ~7.5MB (`bookworm-slim` is ~75MB).

I've also improved the healthcheck by checking if the server is responding or not. The previous healthcheck by running `mollysocket connection list` seemed a bit unsecure too, as docker keeps track of the last output of the healthcheck command so docker would show _all_ registered connections with their uuid & password 😨 

I've also reduced the healthcheck interval from 5m to 1m, by default the healthcheck needs to fail 3 times before docker will consider the container unhealthy. So with an interval of 5m it would take 15 minutes before a container becomes unhealthy which seems bit long.

Changes from commit message:
> feat: use bookworm-slim container for runtime
> feat: add default values for MOLLY_HOST and MOLLY_PORT env variables
> feat: remove apt lists cache after install
> feat: improve health check by ensuring the server is running
> feat: reduce healthcheck interval to 1m