### PR TITLE
Create EcKey without intermediate Pkey in gen_vapid_key()

### DIFF
--- a/src/vapid.rs
+++ b/src/vapid.rs
@@ -187,8 +187,8 @@ fn get_signer(private_bytes: &str) -> Result<SignerWithPubKey> {
 Generate a new VAPID key.
 */
 pub fn gen_vapid_key() -> String {
-    let key = PKey::ec_gen("P-256").unwrap();
-    URL_SAFE_NO_PAD.encode(key.ec_key().unwrap().private_key().to_vec())
+    let key = EcKey::generate(&EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap());
+    URL_SAFE_NO_PAD.encode(key.unwrap().private_key().to_vec())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This fixes building with LibreSSL as PKey::ec_gen() is not supported by it, whereas EcKey::generate() is.
Fixes #58.