### PR TITLE
Fix Overview mermaid graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ graph TD
         D[fa:fa-tower-broadcast Distributor App]
         MA[fa:fa-tablets Molly Android]
     end
-    MS -- 1. Persistent connection --> S
-    MS -- 2. 'Notifications present' --> P
-    P -- 3. 'Notications present for Molly' --> D
-    D -- 4. 'Check Signal servers' --> MA
-    MA -- 5. 'Got messages?' --> S
-    S -- 6. Messages --> MA
+    MS -- #8203;1. Persistent connection --> S
+    MS -- #8203;2. 'Notifications present' --> P
+    P -- #8203;3. 'Notifications present for Molly' --> D
+    D -- #8203;4. 'Check Signal servers' --> MA
+    MA -- #8203;5. 'Got messages?' --> S
+    S -- #8203;6. Messages --> MA
 ```
 
 ## Setup


### PR DESCRIPTION
<details><summary>Currently the graph looks like this</summary>

![](https://github.com/user-attachments/assets/fa1c1a95-2809-45ea-87fb-e7f45d106004)

</details>

note that the "Unsupported markdown: list" are not very readable ;)

This PR fixes this by adding a "ZERO WIDTH SPACE" so that the ``1.``, ``2.``, ``3.``... are not interpreted as lists