### PR TITLE
Support SIGTERM

### DIFF
--- a/mollysocket.service
+++ b/mollysocket.service
@@ -25,7 +25,6 @@ ProtectHome=true
 ProtectSystem=true
 
 ExecStart=ms server
-KillSignal=SIGINT
 
 Restart=on-failure
 


### PR DESCRIPTION
This makes it much easier to run MollySocket on FreeBSD but probably also has benefits for other use cases too.