### PR TITLE
Fix non-unix "sigterm" workaround

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -38,7 +38,7 @@ pub async fn run() {
     #[cfg(unix)]
     let sigterm_future = sigterm_stream.recv().fuse();
     #[cfg(not(unix))]
-    let sigterm_future = std::future::pending().fuse();
+    let sigterm_future = std::future::pending::<()>().fuse();
     let joined_future = join(web::launch().fuse(), connections::run().fuse());
 
     pin_mut!(sigint_future, sigterm_future, joined_future);


### PR DESCRIPTION
I tested this and fixed it and then I forgot to commit it.

Really sorry about this.

Without this, you end up with:

```
error[E0282]: type annotations needed
  --> src/server.rs:41:26
   |
41 |     let sigterm_future = std::future::pending().fuse();
   |                          ^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `pending`
```