### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,7 +63,7 @@ To find the MollySocket QR code:
 
 - If you can use port-forwarding through SSH to your server, then run the following command: `ssh -L 8020:localhost:8020 your_server`, then open http://localhost:8020 on your machine. You can ignore alerts if there are any. Then click on _airgapped mode_.
 
-- If you can't use port-forwarding, change `webserver` to `false` in your config file (_/opt/mollysocket/prod.toml_) and restart your service:
+- If you can't use port-forwarding, change `webserver` to `false` in your config file (_/etc/mollysocket/conf.toml_) and restart your service:
 
 ```console
 # systemctl restart mollysocket
@@ -71,9 +71,9 @@ To find the MollySocket QR code:
 # # This should show a QR code
 ```
 
-After scanning the QR code, you will have a command to copy to run on your server. You must run this command as user `mollysocket` with `MOLLY_CONF=/opt/mollysocket/prod.toml`.
+After scanning the QR code, you will have a command to copy to run on your server. You must run this command as user `mollysocket` with `MOLLY_CONF=/etc/mollysocket/conf.toml`.
 
-For instance `sudo -su mollysocket MOLLY_CONF=/opt/mollysocket/prod.toml /opt/mollysocket/ms connection add baab32b9-d60b-4c39-9e14-15d8f6e1527e 2 thisisrandom 'https://push.mydomain.tld/upthisisrandom?up'`.
+For instance `sudo -su mollysocket MOLLY_CONF=/etc/mollysocket/conf.toml /usr/local/bin/ms connection add baab32b9-d60b-4c39-9e14-15d8f6e1527e 2 thisisrandom 'https://push.mydomain.tld/upthisisrandom?up'`.
 
 ## (Optional) More restrictive configuration
 


### PR DESCRIPTION
- Edited the paths to the configuration file in the command examples to reflect documentation in the global repository;
- Fixed typo in path to local binary;

1.While following the documentation I found myself confused as to why some instructions used /opt/* and others used /etc/* as the prefixes for the database and config files, this should clear that confusion.

2.Regarding the path to the binary, I really can't see how it isn't a typo, since I can't understand why anyone would write "ms" to BOTH "/usr/local/bin" AND "/opt/mollysocket". Additionaly, there was no previous mention of moving the binary to the latter.