### PR TITLE
Fix panic when there is no home directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -157,8 +157,9 @@ fn get_config_path(cli_config_path: Option<PathBuf>) -> Option<PathBuf> {
     }
 
     // from xdg_config_home
-    let proj_dirs = ProjectDirs::from("org", "mollyim", "mollysocket").unwrap();
-    paths.push(proj_dirs.config_dir().join("config.toml"));
+    if let Some(proj_dirs) = ProjectDirs::from("org", "mollyim", "mollysocket") {
+        paths.push(proj_dirs.config_dir().join("config.toml"));
+    }
 
     // in current directory
     paths.push(PathBuf::from("./mollysocket.toml"));


### PR DESCRIPTION
MollySocket tries to find a config file in the user's home directory.
This commit fixes a panic when the user has no home directory. This can
happen when a sandboxed systemd service executes MollySocket.
