### PR TITLE
Add config option to disable metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ The configuration file uses the [TOML format](https://toml.io/). Below is an ove
 |                        | MOLLY_CONF                 | -c \*       | Path to the configuration file, optional          |                      | /etc/mollysocket.conf                                   |
 | host                   | MOLLY_HOST              \* |             | Listening address of the web server               | 127.0.0.1            | 0.0.0.0                                                 |
 | port                   | MOLLY_PORT              \* |             | Listening port of the web server                  | 8020                 | 8080                                                    |
-| webserver              | MOLLY_WEBSERVER         \* |             | Wether to start the web server                    | true                 | false                                                   |
+| webserver              | MOLLY_WEBSERVER         \* |             | Whether to start the web server                   | true                 | false                                                   |
+| metrics                | MOLLY_METRICS           \* |             | Whether to expose the metrics endpoint            | true                 | false                                                   |
 | allowed_endpoints      | MOLLY_ALLOWED_ENDPOINTS \* |             | List of UnifiedPush servers                       | `["*"]`              | `["*"]`,`["https://yourdomain.tld","https://ntfy.sh"]`  |
 | allowed_uuids          | MOLLY_ALLOWED_UUIDS     \* |             | UUIDs of signal accounts that may use this server | `["*"]`              | `["*"]`, `["abcdef-12345-tuxyz-67890"]`                 |
 | db                     | MOLLY_DB                \* |             | Path to the DB                                    | `db.sqlite`          | `"/data/ms.sqlite"`                                     |

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ struct Config {
     host: String,
     port: u16,
     webserver: bool,
+    metrics: bool,
     vapid_privkey: Option<String>,
     vapid_key_file: Option<String>,
     signal_env: SignalEnvironment,
@@ -42,6 +43,7 @@ impl Default for Config {
             host: String::from("127.0.0.1"),
             port: 8020,
             webserver: true,
+            metrics: true,
             vapid_privkey: None,
             vapid_key_file: None,
             signal_env: SignalEnvironment::Production,
@@ -75,6 +77,10 @@ pub fn is_uuid_valid(uuid: &str) -> bool {
 
 pub fn should_start_webserver() -> bool {
     get_cfg().webserver
+}
+
+pub fn should_mount_metrics() -> bool {
+    get_cfg().metrics
 }
 
 pub fn get_vapid_privkey() -> Option<&'static str> {

--- a/src/server/web.rs
+++ b/src/server/web.rs
@@ -319,12 +319,20 @@ pub async fn launch() {
         .merge(("address", config::get_host()))
         .merge(("port", config::get_port()));
 
-    let _ = rocket::build()
+    let rocket = rocket::build()
         .configure(rocket_cfg)
-        .mount("/", routes![index, discover, register])
-        .mount_metrics("/metrics", &METRICS)
-        .launch()
-        .await;
+        .mount("/", routes![index, discover, register]);
+
+        if config::should_mount_metrics() {
+            let _ = rocket
+                .mount_metrics("/metrics", &METRICS)
+                .launch()
+                .await;
+        } else {
+            let _ = rocket
+                .launch()
+                .await;
+        }
 }
 
 fn log_qr_code() {


### PR DESCRIPTION
This pull request adds a new config option:

```toml
metrics = true
````

When set to `false`, MollySocket will not expose the `/metrics` endpoint. This is useful if you're not using the metrics for anything, and want to secure them from public access (see #69). The default value is left at `true` to preserve the previous MollySocket behaviour.

Note that I have almost never written anything in Rust - scrutinize my code accordingly.
