### PR TITLE
Containerfile.alpine: remove unnecessary cache deletion in build stage

### DIFF
--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -2,8 +2,7 @@ FROM rust:alpine AS builder
 WORKDIR app
 
 RUN apk -U upgrade \
-    && apk add musl-dev openssl-dev openssl-libs-static sqlite-dev sqlite-static \
-    && rm -rf /var/cache/apk/*
+    && apk add musl-dev openssl-dev openssl-libs-static sqlite-dev sqlite-static
 
 COPY . .
 RUN cargo build --release --bin mollysocket
@@ -16,8 +15,7 @@ ENV MOLLY_HOST=0.0.0.0
 ENV MOLLY_PORT=8020
 
 RUN apk -U upgrade \
-    && apk add ca-certificates \
-    && rm -rf /var/cache/apk/*
+    && apk add --no-cache ca-certificates
 
 COPY --from=builder /app/target/release/mollysocket /usr/local/bin/
 HEALTHCHECK --interval=1m --timeout=3s \


### PR DESCRIPTION
I noticed this was in the Dockerfile and not only does modern Alpine allow package installs without cache via a flag (which I did in runtime), doing so in the build stage is unnecessary and won't affect anything since only the Mollysocket binary is being copied.