### PR TITLE
fix(cron): skip rebuild when base images are unchanged

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -61,8 +61,40 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve base image digests
+        id: base-digests
+        run: |
+          if [ "${{ matrix.flavor }}" = "alpine" ]; then
+            BUILDER_IMAGE="rust:alpine"
+            RUNTIME_IMAGE="alpine:latest"
+          else
+            BUILDER_IMAGE="rust:bookworm"
+            RUNTIME_IMAGE="debian:bookworm-slim"
+          fi
+
+          BUILDER_DIGEST=$(docker buildx imagetools inspect "$BUILDER_IMAGE" --format '{{.Manifest.Digest}}')
+          RUNTIME_DIGEST=$(docker buildx imagetools inspect "$RUNTIME_IMAGE" --format '{{.Manifest.Digest}}')
+
+          echo "builder=$BUILDER_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "runtime=$RUNTIME_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "Builder digest: $BUILDER_DIGEST"
+          echo "Runtime digest: $RUNTIME_DIGEST"
+
+      - name: Check if base images changed since last build
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: .base-image-digest-marker
+          key: base-image-digests-${{ matrix.flavor }}-${{ steps.base-digests.outputs.builder }}-${{ steps.base-digests.outputs.runtime }}
+
+      - name: Create digest marker file
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "${{ steps.base-digests.outputs.builder }}" > .base-image-digest-marker
+          echo "${{ steps.base-digests.outputs.runtime }}" >> .base-image-digest-marker
+
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.cache.outputs.cache-hit != 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -70,6 +102,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         flavor: ['debian', 'alpine']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-tags: true
           filter: blob:none
@@ -36,7 +36,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -59,10 +59,10 @@ jobs:
             type=semver,pattern={{major}}-${{matrix.flavor}},value=${{ steps.checkout.outputs.tag }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Resolve base image digests
         id: base-digests
@@ -85,7 +85,7 @@ jobs:
 
       - name: Check if base images changed since last build
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .base-image-digest-marker
           key: base-image-digests-${{ matrix.flavor }}-${{ steps.base-digests.outputs.builder }}-${{ steps.base-digests.outputs.runtime }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request' && steps.cache.outputs.cache-hit != 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Build and push
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         flavor: ['debian', 'alpine']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         flavor: ['debian', 'alpine']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-tags: true
           filter: blob:none
@@ -25,7 +25,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -48,10 +48,10 @@ jobs:
             type=semver,pattern={{major}}-${{matrix.flavor}},value=${{ steps.checkout.outputs.tag }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set Up containerd image store
         shell: bash
@@ -61,7 +61,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build and publish
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -100,7 +100,7 @@ jobs:
           done
 
       - name: Archive artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-${{ matrix.flavor }}
           path: |
@@ -113,10 +113,10 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: artifacts-*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install deps
       run: sudo apt update -y && sudo apt install -y libsqlite3-dev
     - name: Run tests


### PR DESCRIPTION
Fixes #108

## Problem

The cron workflow rebuilds and pushes Docker images daily unconditionally, even when nothing has changed. This causes tools like Watchtower to pull a "new" image every day despite no actual update.

## Solution

Before building, resolve the digest of each base image (`rust:bookworm`, `debian:bookworm-slim`, `rust:alpine`, `alpine:latest`) using `docker buildx imagetools inspect`. Use `actions/cache` keyed on those digests:

- **Cache miss** (base image updated): proceed with build and push as normal
- **Cache hit** (nothing changed): skip `Build and push` entirely — no new image is pushed, Watchtower sees nothing new

## Results

Tested on fork [lone-cloud/mollysocket](https://github.com/lone-cloud/mollysocket/actions/workflows/cron.yml):

- First run (cache miss): builds normally (~55m alpine, ~1h32m debian)
- Second run (same digests, cache hit): completes in **22s** / **24s** with no push

Also bumps all GitHub Actions to Node.js 24 compatible versions (current versions will be deprecated on June 2nd, 2026).